### PR TITLE
clipboard warcher thread and event

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -15,7 +15,8 @@ env = SConscript("godot-cpp/SConstruct")
 # tweak this if you want to use different folders, or more folders, to store your source code in.
 env["ENV"] = os.environ
 env.Append(CPPPATH=["src/"])
-env.Append(LIBS=['X11', 'X11-xcb', 'xcb', 'xcb-composite', 'xcb-image', 'xcb-randr'])
+#env.Append(LIBS=['X11', 'Xfixes', 'X11-xcb', 'xcb', 'xcb-composite', 'xcb-image', 'xcb-randr'])
+env.Append(LIBS=['X11', 'X11-xcb', 'xcb', 'xcb-composite', 'xcb-image', 'xcb-randr', 'xcb-xfixes'])
 sources = Glob("src/*.cpp")
 
 if env["platform"] == "linux":

--- a/shell.nix
+++ b/shell.nix
@@ -11,11 +11,11 @@ let
 	libXrender
 	libXi
 	libXext
-	libXfixes
 	libxcb
 	xcbutilerrors
 	xcbutilimage
 	xcbutilrenderutil
+	xcbutil
 	xcbutilwm
 	]);
 in

--- a/src/Xorg.cpp
+++ b/src/Xorg.cpp
@@ -8,11 +8,11 @@
 #include <godot_cpp/variant/color_names.inc.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/variant/variant.hpp>
-//#include <X11/Xlib.h>
-//#include <X11/Xlib-xcb.h>
 #include <xcb/xcb.h>
 #include <xcb/composite.h>
+#include <xcb/xcb_aux.h>
 #include <xcb/xcb_image.h>
+#include <xcb/xfixes.h>
 #include "Xorg.h"
 
 using namespace godot;
@@ -24,10 +24,12 @@ void Xorg::_bind_methods() {
   ClassDB::bind_method(D_METHOD("get_wm_window", "p_index"), &Xorg::get_wm_window);
   ClassDB::bind_method(D_METHOD("get_wm_window_texture", "p_index"), &Xorg::get_wm_window_texture);
   ClassDB::bind_method(D_METHOD("capture_window", "p_index"), &Xorg::capture_window);
+  ClassDB::bind_method(D_METHOD("set_NET_WM_DESKTOP", "p_index", "value"), &Xorg::set_net_wm_desktop);
   // signals
   ADD_SIGNAL(MethodInfo("window_created", PropertyInfo(Variant::OBJECT, "window_info")));
   ADD_SIGNAL(MethodInfo("window_destroyed", PropertyInfo(Variant::OBJECT, "window_info")));
   ADD_SIGNAL(MethodInfo("window_configured", PropertyInfo(Variant::OBJECT, "window_info")));
+  ADD_SIGNAL(MethodInfo("clipboard_notify", PropertyInfo(Variant::INT, "window_id")));
 }
 
 Xorg::Xorg() {
@@ -51,6 +53,55 @@ Xorg::~Xorg() {
 
 void Xorg::_ready() {
   UtilityFunctions::print("[mindwm]: Xorg module initialized");
+}
+
+void Xorg::set_net_wm_desktop(int p_index, uint64_t val) {
+  ERR_FAIL_INDEX(p_index, windows.size());
+
+  xcb_atom_t ATOM__NET_WM_DESKTOP = get_atom("_NET_WM_DESKTOP");
+  xcb_atom_t ATOM__NET_WM_STATE = get_atom("_NET_WM_STATE");
+  xcb_atom_t ATOM__NET_WM_STATE_STICKY = get_atom("_NET_WM_STATE_STICKY");
+//  xcb_atom_t ATOM__NET_WM_STATE_ABOVE = get_atom("_NET_WM_STATE_ABOVE");
+//  xcb_atom_t ATOM__NET_WM_STATE_SKIP_TASKBAR = get_atom("_NET_WM_STATE_SKIP_TASKBAR");
+//  xcb_atom_t ATOM__NET_WM_STATE_SKIP_PAGER = get_atom("_NET_WM_STATE_SKIP_PAGER");
+  xcb_atom_t ATOM__NET_WM_WINDOW_TYPE = get_atom("_NET_WM_WINDOW_TYPE");
+  xcb_atom_t ATOM__NET_WM_WINDOW_TYPE_DOCK = get_atom("_NET_WM_WINDOW_TYPE_DOCK");
+
+  xcb_change_property(conn,
+    XCB_PROP_MODE_REPLACE,
+    windows[p_index]->get_win_id(),
+    ATOM__NET_WM_WINDOW_TYPE,
+    XCB_ATOM_ATOM,
+    32,
+    1,
+    &ATOM__NET_WM_WINDOW_TYPE_DOCK);
+
+  uint32_t data[] = {0xFFFFFFFF};
+  xcb_change_property(conn,
+    XCB_PROP_MODE_REPLACE,
+    windows[p_index]->get_win_id(),
+    ATOM__NET_WM_DESKTOP,
+    XCB_ATOM_CARDINAL,
+    32,
+    1,
+    (const void*)data);
+
+  uint32_t states[] = {
+    ATOM__NET_WM_STATE_STICKY,
+ //   ATOM__NET_WM_STATE_ABOVE,
+ //   ATOM__NET_WM_STATE_SKIP_TASKBAR,
+ //   ATOM__NET_WM_STATE_SKIP_PAGER
+  };
+  xcb_change_property(conn,
+    XCB_PROP_MODE_REPLACE,
+    windows[p_index]->get_win_id(),
+    ATOM__NET_WM_STATE,
+    XCB_ATOM_ATOM,
+    32,
+    1,
+    (const void*) states);
+
+  xcb_flush(conn);
 }
 
 Ref<XorgWindowInfo> Xorg::get_wm_window(int p_index) {
@@ -100,32 +151,129 @@ TypedArray<XorgWindowInfo> Xorg::list_windows() {
 
 void Xorg::_notification(int p_what) {
   // Don't run if we're in the editor
+  UtilityFunctions::print(vformat("_notification: %s", p_what));
   if (Engine::get_singleton()->is_editor_hint()) {
     return;
   }
 
   switch (p_what) {
-  case NOTIFICATION_READY: {
+//  case NOTIFICATION_READY: {
+  case NOTIFICATION_POSTINITIALIZE: {
     eventsWatcherTerminated = false;
+    clipboardWatcherTerminated = false;
     eventsWatcher.instantiate();
+    UtilityFunctions::print(vformat("starting eventWatcher thread"));
     eventsWatcher->start(callable_mp(this, &Xorg::watchEvents), Thread::PRIORITY_NORMAL);
+    UtilityFunctions::print(vformat("starting clipboardWatcher thread"));
+    clipboardWatcher.instantiate();
+    clipboardWatcher->start(callable_mp(this, &Xorg::watchClipboard), Thread::PRIORITY_NORMAL);
   } break;
   case NOTIFICATION_WM_CLOSE_REQUEST: {
     eventsWatcherTerminated = true;
+    clipboardWatcherTerminated = true;
+    UtilityFunctions::print(vformat("set terminate flag for all watchers"));
     // NOTE: we need to send a dummy event to the root window
     // to unblock the watcher thread and allow it to finish the tasks
     send_xorg_dummy_event();
     if (eventsWatcher.is_valid()) {
       eventsWatcher->wait_to_finish();
+      clipboardWatcher->wait_to_finish();
     }
 
     eventsWatcher.unref();
+    clipboardWatcher.unref();
   };
   }
 }
 
 void Xorg::_process(double delta) {
   time_passed += delta;
+}
+
+xcb_atom_t Xorg::intern_atom(const char *str)
+{
+    xcb_intern_atom_reply_t *rep;
+    xcb_atom_t atom;
+    uint16_t name_len = strlen(str);
+    rep = xcb_intern_atom_reply(conn, xcb_intern_atom(conn, 0, name_len, str), NULL);
+    atom = rep->atom;
+    std::free(rep);
+    return atom;
+}
+
+void Xorg::watchClipboard() {
+  UtilityFunctions::print(vformat("starting clipboard events watcher"));
+  xcb_connection_t *conn;
+  conn = xcb_connect(NULL, NULL);
+  xcb_screen_t *screen;
+  xcb_window_t event_window = xcb_generate_id(conn);
+  xcb_generic_event_t *event;
+  xcb_void_cookie_t cookie;
+
+  screen = xcb_setup_roots_iterator(xcb_get_setup(conn)).data;
+
+  const xcb_query_extension_reply_t *query_ext = xcb_get_extension_data(conn, &xcb_xfixes_id);
+
+  uint32_t flags[] =  { XCB_EVENT_MASK_PROPERTY_CHANGE };
+  xcb_create_window(conn, screen->root_depth, event_window, screen->root,
+    -1, -1, 1, 1, 0, XCB_COPY_FROM_PARENT,
+    screen->root_visual, XCB_CW_EVENT_MASK,
+    flags);
+  xcb_discard_reply(conn, xcb_xfixes_query_version(conn, 1, 0).sequence);
+
+  xcb_atom_t selection = intern_atom("CLIPBOARD");
+  xcb_xfixes_select_selection_input(conn, event_window, selection,
+            XCB_XFIXES_SELECTION_EVENT_MASK_SET_SELECTION_OWNER |
+            XCB_XFIXES_SELECTION_EVENT_MASK_SELECTION_WINDOW_DESTROY |
+            XCB_XFIXES_SELECTION_EVENT_MASK_SELECTION_CLIENT_CLOSE);
+
+  xcb_flush(conn);
+
+  while ((event = xcb_wait_for_event(conn))) {
+    UtilityFunctions::print(vformat("[clipboardWatcher]: new event: 0x%x", event->response_type & ~0x7f));
+    if (clipboardWatcherTerminated)
+      break;
+
+    uint8_t type = event->response_type & 0x7f;
+//    UtilityFunctions::print(vformat("[clipboardWatcher]: event type: 0x%x", type));
+    if (query_ext != NULL && type == query_ext->first_event + XCB_XFIXES_SELECTION_NOTIFY) {
+      xcb_xfixes_selection_notify_event_t *ev = (xcb_xfixes_selection_notify_event_t *) event;
+//      UtilityFunctions::print(vformat("[clipboardWatcher]: Selection changed, new owner is 0x%x\n", ev->owner));
+      /*
+      Ref<XorgWindowInfo> win;
+      win = find_window_by_id(ev->owner);
+      if (!win.is_valid())
+        win = find_window_by_parent_id(ev->owner);
+
+      ERR_FAIL_COND_MSG(!win.is_valid(), vformat("failed to find XorgWindowInfo for 0x%x", ev->owner));
+      */
+      call_deferred("emit_signal", "clipboard_notify", ev->owner);
+    }
+    else {
+      switch (type) {
+        case 0:
+          {
+            xcb_generic_error_t *generr = (xcb_generic_error_t *) event;
+            UtilityFunctions::print(vformat("[clipboardWatcher]: Got error %d from request %d:%d\n",
+            generr->error_code, generr->major_code,
+            generr->minor_code));
+          }
+          break;
+        case XCB_SELECTION_NOTIFY:
+          {
+      	    call_deferred("emit_signal", "clipboard_notify");
+  	      }
+          break;
+        default:
+          {
+            UtilityFunctions::print(vformat("[clipboardWatcher]: Got unexpected event %d\n", event->response_type));
+          }
+      }
+    }
+    std::free(event);
+    xcb_flush(conn);
+  }
+  xcb_disconnect(conn);
 }
 
 void Xorg::watchEvents() {
@@ -148,11 +296,13 @@ void Xorg::watchEvents() {
         | XCB_EVENT_MASK_STRUCTURE_NOTIFY
         }
         );
+
   xcb_flush(conn);
 
   ERR_FAIL_COND(xcb_request_check(conn, cookie));
 
   while ((event = xcb_wait_for_event(conn))) {
+    UtilityFunctions::print(vformat("[eventsWatcher]: new event 0x%x", event->response_type & ~0x80));
     if (eventsWatcherTerminated)
       break;
 
@@ -161,8 +311,8 @@ void Xorg::watchEvents() {
         {
         xcb_create_notify_event_t *create_event = (xcb_create_notify_event_t *)event;
         if (create_event->width > 1 || create_event->height > 1) {
-          UtilityFunctions::print(vformat("new window event: 0x%08x (0x%08x)", create_event->window, create_event->parent));
-          UtilityFunctions::print(vformat("\tWxH (%dx%d)", create_event->width, create_event->height));
+          UtilityFunctions::print(vformat("[eventsWatcher]: new window event: 0x%08x (0x%08x)", create_event->window, create_event->parent));
+          UtilityFunctions::print(vformat("[eventsWatcher]: \tWxH (%dx%d)", create_event->width, create_event->height));
           add_window(create_event->window, create_event->parent);
         }
         else {
@@ -173,17 +323,17 @@ void Xorg::watchEvents() {
       case XCB_DESTROY_NOTIFY:
         {
         xcb_destroy_notify_event_t *destroy_event = (xcb_destroy_notify_event_t *)event;
-        UtilityFunctions::print(vformat("destroy window event: 0x%08x", destroy_event->window));
+        UtilityFunctions::print(vformat("[eventsWatcher]: destroy window event: 0x%08x", destroy_event->window));
         Ref<XorgWindowInfo> w;
         w = find_window_by_id(destroy_event->window);
         if (w != NULL) {
-          UtilityFunctions::print(vformat("destroy by win_id 0x%x", w->get_win_id()));
+          UtilityFunctions::print(vformat("[eventsWatcher]: destroy by win_id 0x%x", w->get_win_id()));
           remove_window(w);
         }
         else {
           w = find_window_by_parent_id(destroy_event->window);
           if (w != NULL) {
-            UtilityFunctions::print(vformat("destroy by parent_id 0x%x", w->get_win_id()));
+            UtilityFunctions::print(vformat("[eventsWatcher]: destroy by parent_id 0x%x", w->get_win_id()));
             remove_window(w);
           }
         }
@@ -192,12 +342,12 @@ void Xorg::watchEvents() {
       case XCB_REPARENT_NOTIFY:
         {
         xcb_reparent_notify_event_t *reparent_event = (xcb_reparent_notify_event_t *)event;
-        UtilityFunctions::print(vformat("reparent window event: 0x%08x new parent 0x%x", reparent_event->window, reparent_event->parent));
+        UtilityFunctions::print(vformat("[eventsWatcher]: reparent window event: 0x%08x new parent 0x%x", reparent_event->window, reparent_event->parent));
 
         Ref<XorgWindowInfo> w;
         w = find_window_by_id(reparent_event->window);
         if (w != NULL) {
-          UtilityFunctions::print(vformat("set parent: 0x%08x old 0x%x new 0x%x", w->get_win_id(), w->get_parent_id(), reparent_event->parent));
+          UtilityFunctions::print(vformat("[eventsWatcher]: set parent: 0x%08x old 0x%x new 0x%x", w->get_win_id(), w->get_parent_id(), reparent_event->parent));
           w->set_parent_id(reparent_event->parent);
         }
 
@@ -206,7 +356,7 @@ void Xorg::watchEvents() {
       case XCB_CONFIGURE_NOTIFY:
         {
         xcb_configure_notify_event_t *configure_event = (xcb_configure_notify_event_t *)event;
-        UtilityFunctions::print(vformat("configure window event: 0x%08x Rect(%d, %d, %d, %d)",
+        UtilityFunctions::print(vformat("[eventsWatcher]: configure window event: 0x%08x Rect(%d, %d, %d, %d)",
               configure_event->window,
               configure_event->x,
               configure_event->y,
@@ -222,6 +372,7 @@ void Xorg::watchEvents() {
         }
     }
     std::free(event);
+    xcb_flush(conn);
   }
   xcb_disconnect(conn);
 }
@@ -358,7 +509,7 @@ void Xorg::add_window(xcb_window_t win, xcb_window_t parent) {
   Ref<XorgWindowTexture> win_tex;
   win_tex.instantiate();
   window_textures.push_back(win_tex);
-  UtilityFunctions::print(vformat("[mindwm]: Xorg texRID: %s", win_tex->get_rid()));
+//  UtilityFunctions::print(vformat("[mindwm]: Xorg texRID: %s", win_tex->get_rid()));
   call_deferred("emit_signal", "window_created", xw);
 }
 

--- a/src/Xorg.h
+++ b/src/Xorg.h
@@ -16,6 +16,8 @@ class Xorg : public Node {
 private:
   void *disp = NULL;
   Ref<Thread> eventsWatcher;
+  Ref<Thread> clipboardWatcher;
+  bool clipboardWatcherTerminated;
   bool eventsWatcherTerminated;
   xcb_connection_t* conn;
   Vector<Ref<XorgWindowInfo>> windows;
@@ -26,6 +28,7 @@ private:
   xcb_atom_t get_atom(const char *atom_name);
   xcb_window_t get_window_parent(xcb_window_t win);
   xcb_get_property_reply_t* get_win_property(xcb_window_t win, xcb_atom_t atom);
+  xcb_atom_t intern_atom(const char *str);
   bool xcomp_check_ewmh(xcb_window_t root);
   String get_win_text_property(xcb_window_t win, xcb_atom_t atom);
   void add_window(xcb_window_t win, xcb_window_t parent);
@@ -33,6 +36,7 @@ private:
   void configure_window(Ref<XorgWindowInfo> w, Rect2i rect);
   void list_xorg_windows();
   void watchEvents();
+  void watchClipboard();
   void capture_window(int p_window_index);
 
 protected:
@@ -43,6 +47,7 @@ public:
 	Xorg();
 	~Xorg();
 
+  void set_net_wm_desktop(int p_index, uint64_t val);
   Ref<XorgWindowInfo> get_wm_window(int p_index);
   Ref<XorgWindowTexture> get_wm_window_texture(int p_index);
   Ref<XorgWindowInfo> find_window_by_id(xcb_window_t win_id);


### PR DESCRIPTION
q'n'd implementation of x11 clipboard events catching. Dedicated thread started to create a zero-size window to get all clipboard notification via xfixes workaround.

PS. `set_net_wm_desktop` not really needed for clipboard events catchin. This is approach to make a main window sticky and place it on all workspaces. It works but in case of chainging parameters of alreafy existent window it needs to unmap and map the window again, which makes Godot to unable catch any events at all. Need more investigation of this.